### PR TITLE
Basic TLS support, handle lowercase 'upgrade'

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,8 +50,9 @@ function ReverseServer (opts, onRequest) {
           server.emit('error', err)
           server.close()
         } else if (head.statusCode === 101 &&
-            head.headers.upgrade === 'PTTH/1.0' &&
-            head.headers.connection === 'Upgrade') {
+            head.headers.connection &&
+            head.headers.connection.toLowerCase() === 'upgrade' &&
+            head.headers.upgrade === 'PTTH/1.0') {
           server.emit('connection', server._socket)
         } else {
           server.emit('error', new Error('Unexpected response to PTTH/1.0 Upgrade request'))


### PR DESCRIPTION
We're running a custom PTTH server behind nginx. Nginx handles TLS for us, but also appears to lowercase the `Connection` header value. This PR adds support for TLS and fixes the latter issue.
